### PR TITLE
Bug Fixes in term_collector.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.1.0'
+version = '1.1.1'
 description = 'A tool for mapping free-text descriptions of (biomedical) entities to controlled terms in an ontology'
 long_description = open('README.md').read()
 

--- a/text2term/__init__.py
+++ b/text2term/__init__.py
@@ -1,3 +1,7 @@
 from .t2t import map_terms
 from .t2t import map_file
+from .t2t import cache_ontology_set
+from .t2t import cache_ontology
+from .t2t import cache_exists
+from .t2t import clear_cache
 from .mapper import Mapper

--- a/text2term/term_collector.py
+++ b/text2term/term_collector.py
@@ -46,12 +46,16 @@ class OntologyTermCollector:
         return ontology_terms
 
     def filter_terms(self, onto_terms, iris=(), excl_deprecated=False):
-        for term in onto_terms:
-            begins_with_iri = (iris == ()) or any(term.iri().startswith(iri) for iri in iris)
-            is_not_depricated = (excl_deprecated and not term.deprecated()) or (not excl_deprecated)
-            if not (begins_with_iri and is_not_depricated):
-                onto_terms.pop(term.iri())
-        return onto_terms
+        filtered_onto_terms = {}
+        for base_iri, term in onto_terms.items():
+            if type(iris) == str:
+                begins_with_iri = (iris == ()) or base_iri.startswith(iris)
+            else:
+                begins_with_iri = (iris == ()) or any(base_iri.startswith(iri) for iri in iris)
+            is_not_depricated = (not excl_deprecated) or (not term.deprecated)
+            if begins_with_iri and is_not_depricated:
+                filtered_onto_terms.update({base_iri: term})
+        return filtered_onto_terms
 
     def _get_ontology_terms(self, term_list, ontology, exclude_deprecated):
         ontology_terms = dict()
@@ -112,7 +116,6 @@ class OntologyTermCollector:
                         instances.update({instance.iri: instance.label[0]})
                     else:
                         instances.update({instance.iri: onto_utils.label_from_iri(instance.iri)})
-                instances[instance.iri] = instance.label[0]
         except AttributeError as err:
             self.logger.debug(err)
         return instances


### PR DESCRIPTION
Fixes the known bugs in the filtering function, which prevented the user from filtering on the base IRIs while using a cached ontology. Also fixed a bug that prevented the tool from working with stored terms.