### PR TITLE
Include imported ontologies & additional synonym types + improved logging + other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,18 +28,18 @@ text2term.map_file(input_file='/some/file.txt',
 ```
 or
 ```python
-map_terms(source_terms=['term one', 'term two'], 
-          target_ontology='http://some.ontology/v1.owl', 
-          base_iris=(), 
-          excl_deprecated=False, 
-          max_mappings=3, 
-          min_score=0.3, 
-          mapper=Mapper.TFIDF, 
-          output_file='', 
-          save_graphs=False, 
-          save_mappings=False, 
-          source_terms_ids=(), 
-          use_cache=False)
+text2term.map_terms(source_terms=['term one', 'term two'],
+                    target_ontology='http://some.ontology/v1.owl',
+                    base_iris=(),
+                    excl_deprecated=False,
+                    max_mappings=3,
+                    min_score=0.3,
+                    mapper=Mapper.TFIDF,
+                    output_file='',
+                    save_graphs=False,
+                    save_mappings=False,
+                    source_terms_ids=(),
+                    use_cache=False)
 ```
 
 ### Arguments

--- a/README.md
+++ b/README.md
@@ -1,21 +1,49 @@
-# text2term ontology mapper
-
+# *text2term* ontology mapper
 A tool for mapping free-text descriptions of (biomedical) entities to controlled terms in an ontology. 
 
-## Programmatic Usage
+## Installation
 Install package using **pip**:
 
-`pip install text2term`
+```
+pip install .
+```
 
+## Programmatic Usage
 The tool can be executed in Python with either of the two following functions:
-`text2term.map_files(input_file, target_ontology, base_iris=(), csv_columns=(), excl_deprecated=False, max_mappings=3, mapper=Mapper.TFIDF,min_score=0.3, output_file='', save_graphs=False, save_mappings=False, separator=',', use_cache=False)`
 
+```python
+text2term.map_file(input_file='/some/file.txt', 
+                   target_ontology='http://some.ontology/v1.owl',
+                   base_iris=(),
+                   csv_columns=(), 
+                   excl_deprecated=False, 
+                   max_mappings=3, 
+                   mapper=Mapper.TFIDF,
+                   min_score=0.3, 
+                   output_file='', 
+                   save_graphs=False, 
+                   save_mappings=False, 
+                   separator=',', 
+                   use_cache=False)
+```
 or
-
-`map_terms(source_terms, target_ontology, base_iris=(), excl_deprecated=False, max_mappings=3, min_score=0.3, mapper=Mapper.TFIDF, output_file='', save_graphs=False, save_mappings=False, source_terms_ids=(), use_cache=False)`
+```python
+map_terms(source_terms=['term one', 'term two'], 
+          target_ontology='http://some.ontology/v1.owl', 
+          base_iris=(), 
+          excl_deprecated=False, 
+          max_mappings=3, 
+          min_score=0.3, 
+          mapper=Mapper.TFIDF, 
+          output_file='', 
+          save_graphs=False, 
+          save_mappings=False, 
+          source_terms_ids=(), 
+          use_cache=False)
+```
 
 ### Arguments
-For `map_files`, the first argument 'input_file' specifies a path to a file containing the names of every term that needs to be mapped. For `map_terms`, The first argument 'source_terms' takes in a list of the terms to be mapped.
+For `map_file`, the first argument 'input_file' specifies a path to a file containing the terms to be mapped. For `map_terms`, the first argument 'source_terms' takes in a list of the terms to be mapped.
 
 All other arguments are the same, and have the same functionality:
 
@@ -92,11 +120,7 @@ In both cases, the templates must be stored in a newline seperated file.
 
 ## Command Line Usage
 
-Install package using **pip**:
-
-`pip install .`
-
-Execute the tool as follows:
+After installation, execute the tool from a command line as follows:
 
 `python text2term -s SOURCE -t TARGET [-o OUTPUT] [-m MAPPER] [-csv CSV_INPUT] [-top TOP_MAPPINGS] [-min MIN_SCORE] [-iris BASE_IRIS] [-d EXCL_DEPRECATED] [-g SAVE_TERM_GRAPHS]`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ numpy==1.23.2
 gensim==4.1.2
 scipy==1.8.0
 scikit-learn==1.0.2
-setuptools==60.9.3
+setuptools==66.0.0
 requests==2.27.1
 tqdm==4.62.3
 sparse_dot_topn==0.3.1

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.2.0'
+version = '1.2.1'
 description = 'A tool for mapping free-text descriptions of (biomedical) entities to controlled terms in an ontology'
 long_description = open('README.md').read()
 
@@ -27,8 +27,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.9',
-        'Topic :: Scientific/Engineering',
-        'Topic :: Scientific/Engineering :: Bio-Informatics'
+        'Topic :: Scientific/Engineering'
     ],
     python_requires=">=3.9",
 )

--- a/text2term/t2t.py
+++ b/text2term/t2t.py
@@ -1,6 +1,7 @@
 """Provides Text2Term class"""
 
 import os
+import sys
 import json
 import pickle
 import time
@@ -128,7 +129,7 @@ def cache_ontology_set(ontology_registry_path):
         try:
             cache_ontology(row.url, row.acronym)
         except Exception as err:
-            print("Could not cache ontology ", row.acronym, " due to error: ", err)
+            sys.stderr.write("Could not cache ontology", row.acronym, "due to error:", err)
         owlready2.default_world.ontologies.clear()
 
 # Caches a single ontology
@@ -151,13 +152,13 @@ def clear_cache(ontology_acronym=''):
     cache_dir = "cache/" 
     if ontology_acronym != '':
         cache_dir = os.path.join(cache_dir, ontology_acronym)
-    # rm -r cache_dir
+    # Is equivalent to: rm -r cache_dir
     try:
         rmtree(cache_dir)
-        print("Cache has been cleared successfully")
+        sys.stderr.write("Cache has been cleared successfully")
     except OSError as error:
-        print("Cache cannot be removed:")
-        print(error)
+        sys.stderr.write("Cache cannot be removed:")
+        sys.stderr.write(error)
 
 """
 PRIVATE/HELPER FUNCTIONS

--- a/text2term/term_collector.py
+++ b/text2term/term_collector.py
@@ -5,6 +5,7 @@ from text2term import onto_utils
 from text2term.term import OntologyTerm
 import logging
 
+
 class OntologyTermCollector:
 
     def __init__(self, log_level=logging.INFO):
@@ -158,6 +159,8 @@ class OntologyTermCollector:
             synonyms.add(synonym)
         for synonym in self._get_obo_related_synonyms(ontology_term):
             synonyms.add(synonym)
+        for synonym in self._get_obo_broad_synonyms(ontology_term):
+            synonyms.add(synonym)
         for nci_synonym in self._get_nci_synonyms(ontology_term):
             synonyms.add(nci_synonym)
         for efo_alt_term in self._get_efo_alt_terms(ontology_term):
@@ -212,7 +215,7 @@ class OntologyTermCollector:
         synonyms = []
         try:
             for synonym in ontology_term.hasExactSynonym:
-                if synonym.iri is not None:
+                if hasattr(synonym, 'iri'):
                     synonym = synonym.iri
                 synonyms.append(synonym)
         except AttributeError as err:
@@ -229,7 +232,24 @@ class OntologyTermCollector:
         synonyms = []
         try:
             for synonym in ontology_term.hasRelatedSynonym:
-                if synonym.iri is not None:
+                if hasattr(synonym, 'iri'):
+                    synonym = synonym.iri
+                synonyms.append(synonym)
+        except AttributeError as err:
+            self.logger.debug(err)
+        return synonyms
+
+    def _get_obo_broad_synonyms(self, ontology_term):
+        """
+        Collect broad synonyms of the given term that are specified using the annotation property:
+            <http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym>.
+        :param ontology_term: Ontology term to collect broad synonyms from
+        :return: Collection of broad synonyms
+        """
+        synonyms = []
+        try:
+            for synonym in ontology_term.hasBroadSynonym:
+                if hasattr(synonym, 'iri'):
                     synonym = synonym.iri
                 synonyms.append(synonym)
         except AttributeError as err:

--- a/text2term/term_collector.py
+++ b/text2term/term_collector.py
@@ -33,7 +33,8 @@ class OntologyTermCollector:
                 iris = list(default_world.search(iri=query))
                 ontology_terms = ontology_terms | self._get_ontology_terms(iris, ontology, exclude_deprecated)
         else:
-            ontology_terms = self._get_ontology_terms(ontology.classes(), ontology, exclude_deprecated)
+            ontology_signature = self._get_ontology_signature(ontology)
+            ontology_terms = self._get_ontology_terms(ontology_signature, ontology, exclude_deprecated)
         end = time.time()
         self.logger.info("...done: collected %i ontology terms (collection time: %.2fs)", len(ontology_terms),
                          end - start)
@@ -56,6 +57,13 @@ class OntologyTermCollector:
             if begins_with_iri and is_not_deprecated:
                 filtered_onto_terms.update({base_iri: term})
         return filtered_onto_terms
+
+    def _get_ontology_signature(self, ontology):
+        signature = list(ontology.classes())
+        # ontology.classes() does not include classes in imported ontologies; we need to explicitly add them to our list
+        for imported_ontology in ontology.imported_ontologies:
+            signature.extend(list(imported_ontology.classes()))
+        return signature
 
     def _get_ontology_terms(self, term_list, ontology, exclude_deprecated):
         ontology_terms = dict()

--- a/text2term/term_collector.py
+++ b/text2term/term_collector.py
@@ -3,12 +3,12 @@
 from owlready2 import *
 from text2term import onto_utils
 from text2term.term import OntologyTerm
-
+import logging
 
 class OntologyTermCollector:
 
-    def __init__(self):
-        self.logger = onto_utils.get_logger(__name__)
+    def __init__(self, log_level=logging.INFO):
+        self.logger = onto_utils.get_logger(__name__, level=log_level)
 
     def get_ontology_terms(self, ontology_iri, base_iris=(), use_reasoning=False, exclude_deprecated=False):
         """
@@ -43,7 +43,7 @@ class OntologyTermCollector:
         try:
             ontology.destroy()
         except Exception as err:
-            print("Unable to destroy ontology: ", err)
+            self.logger.debug("Unable to destroy ontology: ", err)
         return ontology_terms
 
     def filter_terms(self, onto_terms, iris=(), excl_deprecated=False):

--- a/text2term/term_graph_generator.py
+++ b/text2term/term_graph_generator.py
@@ -24,11 +24,15 @@ class TermGraphGenerator:
             self._add_ancestors(parent_iri, nodes, edges)
 
     def _add_ancestors(self, node_iri, nodes, edges):
-        ancestors = self._terms[node_iri].parents
-        for ancestor_iri in ancestors:
-            self._add_node(ancestor_iri, ancestors[ancestor_iri], nodes)
-            edges.add(Edge(node_iri, ancestor_iri, Edge.IS_A))
-            self._add_ancestors(ancestor_iri, nodes, edges)
+        if node_iri in self._terms:
+            ancestors = self._terms[node_iri].parents
+            for ancestor_iri in ancestors:
+                self._add_node(ancestor_iri, ancestors[ancestor_iri], nodes)
+                edges.add(Edge(node_iri, ancestor_iri, Edge.IS_A))
+                self._add_ancestors(ancestor_iri, nodes, edges)
+        else:
+            self._logger.debug("Unable to get ancestor term %s from the ontology term details dictionary "
+                               "(possibly filtered out through the `base_iris` option)", node_iri)
 
     def _add_children(self, term, children, edge_type, nodes, edges):
         for child_iri in children:


### PR DESCRIPTION
- Include terms from imported ontologies in term collection and mapping
- Collect both OBO 'related' and 'broad' synonyms for use in mapping
- Upgrade version of 'setuptools' to address a security vulnerability 
- Enable serialization of ontology term neighborhood graphs when some ancestors are not present 
- Improve logging and exception handling