### PR TITLE
Source Term ID Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ All other arguments are the same, and have the same functionality:
 
 `source_terms_ids` : tuple
     Collection of identifiers for the given source terms
+    WARNING: While this is still available for the tagged term function, it is worth noting that dictionaries do not necessarily preserve order, so it is not recommended. If using the TaggedTerm object, the source terms can be attached there to guarantee order.
 
 `excl_deprecated` : bool
     Exclude ontology terms stated as deprecated via `owl:deprecated true`
@@ -145,12 +146,14 @@ WARNING: Removing duplicates at any point does not guarantee which original term
 The non-tagged functions both return a dictionary where the keys are the original terms and the values are the preprocessed terms.
 The tagged function returns a list of TaggedTerm items with the following function contracts:
 ```python
-def __init__(self, term=None, tags=[], original_term=None)
+def __init__(self, term=None, tags=[], original_term=None, source_term_id=None)
 def add_tags(self, new_tags)
 def update_term(self, term)
+def update_source_term_id(self, source_term_id)
 def get_original_term(self)
 def get_term(self)
 def get_tags(self)
+def get_source_term_id(self)
 ```
 As mentioned in the mapping section above, this can then be passed directly to map_tagged_terms(), allowing for easy prgorammatic usage. Note that this allows multiple of the same preprocessed term with different tags. 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.0.1'
+version = '2.0.2'
 description = 'A tool for mapping free-text descriptions of (biomedical) entities to controlled terms in an ontology'
 long_description = open('README.md').read()
 

--- a/text2term/__init__.py
+++ b/text2term/__init__.py
@@ -9,3 +9,4 @@ from .mapper import Mapper
 from .preprocess import preprocess_file
 from .preprocess import preprocess_terms
 from .preprocess import preprocess_tagged_terms
+from .tagged_terms import TaggedTerm

--- a/text2term/t2t.py
+++ b/text2term/t2t.py
@@ -77,7 +77,16 @@ def map_tagged_terms(tagged_terms_dict, target_ontology, base_iris=(), excl_depr
     if isinstance(tagged_terms_dict, dict):
         terms = list(tagged_terms_dict.keys())
     else:
-        terms = [tagged_term.get_term() for tagged_term in tagged_terms_dict]
+        terms = []
+        source_terms_id_list = []
+        for tagged_term in tagged_terms_dict:
+            terms.append(tagged_term.get_term())
+            if tagged_term.get_source_term_id() != None:
+                source_terms_id_list.append(tagged_term.get_source_term_id())
+        if len(source_terms_id_list) > 0:
+            source_terms_ids = tuple(source_terms_id_list)
+
+    # Run the mapper
     df = map_terms(terms, target_ontology, base_iris=base_iris, excl_deprecated=excl_deprecated, \
                     max_mappings=max_mappings, min_score=min_score, mapper=mapper, output_file=output_file, \
                     save_graphs=save_graphs, source_terms_ids=source_terms_ids, use_cache=use_cache)
@@ -138,6 +147,8 @@ def map_terms(source_terms, target_ontology, base_iris=(), excl_deprecated=False
         Data frame containing the generated ontology mappings
     """
     if len(source_terms_ids) != len(source_terms):
+        if len(source_terms_ids) > 0:
+            sys.stderr.write("Warning: Source Term Ids are non-zero, but will not be used.")
         source_terms_ids = onto_utils.generate_iris(len(source_terms))
     if output_file == '':
         timestamp = datetime.datetime.now().strftime("%d-%m-%YT%H-%M-%S")

--- a/text2term/tagged_terms.py
+++ b/text2term/tagged_terms.py
@@ -1,9 +1,10 @@
 
 class TaggedTerm:
-	def __init__(self, term=None, tags=[], original_term=None):
+	def __init__(self, term=None, tags=[], original_term=None, source_term_id=None):
 		self.term = term
 		self.tags = tags
 		self.original_term = original_term
+		self.source_term_id = source_term_id
 
 	def __repr__(self):
 		return f"<TaggedTerm term:{self.term} tags:{self.tags} original_term:{self.original_term}"
@@ -14,6 +15,9 @@ class TaggedTerm:
 	def update_term(self, term):
 		self.term = term
 
+	def update_source_term_id(self, source_term_id):
+		self.source_term_id = source_term_id
+
 	def get_original_term(self):
 		return self.original_term
 
@@ -22,4 +26,7 @@ class TaggedTerm:
 
 	def get_tags(self):
 		return self.tags
+
+	def get_source_term_id(self):
+		return self.source_term_id
 		


### PR DESCRIPTION
Fixes bugs pertaining to adding a Source Term ID to the tagged terms. It does this by implementing an extra data member and functions to the TaggedTerms object. There is also a warning if source_terms_ids is not empty but is not used due to unequal length. Also exposes the TaggedTerm object on the top layer of t2t.