### PR TITLE
Add Term Types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,4 +134,3 @@ dmypy.json
 # Other
 .idea
 .DS_Store
-test/*

--- a/.gitignore
+++ b/.gitignore
@@ -84,9 +84,8 @@ ipython_config.py
 # pyenv
 .python-version
 
-# For PyPi upload
+# For PyPi upload and testing
 make-pypi.sh
-test-pypi.py
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/README.md
+++ b/README.md
@@ -13,39 +13,39 @@ pip install text2term
 import text2term
 import pandas
 
-df1 = text2term.map_file(unstruct_terms.txt, "http://www.ebi.ac.uk/efo/efo.owl")
+df1 = text2term.map_file("test/unstruct_terms.txt", "http://www.ebi.ac.uk/efo/efo.owl")
 df2 = text2term.map_terms(["asthma", "acute bronchitis"], "http://www.ebi.ac.uk/efo/efo.owl")
 ```
 Below is an example of caching, assuming the same imports as above:
 ```python
 text2term.cache_ontology("http://www.ebi.ac.uk/efo/efo.owl", "EFO")
-df1 = text2term.map_file(unstruct_terms.txt, "EFO", use_cache=True)
+df1 = text2term.map_file("test/unstruct_terms.txt", "EFO", use_cache=True)
 df2 = text2term.map_terms(["asthma", "acute bronchitis"], "EFO", use_cache=True)
 text2term.clear_cache("EFO")
 ```
 
 ### Command Line
 The basic use of the tool requires a `source` file containing a list of terms to map to the given `target` ontology:  
-`python text2term -s unstruct_terms.txt -t http://www.ebi.ac.uk/efo/efo.owl`
+`python text2term -s test/unstruct_terms.txt -t http://www.ebi.ac.uk/efo/efo.owl`
 
 Specify an output file where the mappings should be saved using `-o`:  
-`python text2term -s unstruct_terms.txt -t efo.owl -o /Documents/my-mappings.csv`
+`python text2term -s test/unstruct_terms.txt -t efo.owl -o /Documents/my-mappings.csv`
 
 Set the minimum acceptable similarity score for mapping each given term to an ontology term using `-min`:  
-`python text2term -s unstruct_terms.txt -t efo.owl -min 0.8`  
+`python text2term -s test/unstruct_terms.txt -t efo.owl -min 0.8`  
 The mapped terms returned will have been determined to be 0.8 similar to their source terms in a 0-1 scale.  
 
 Exclude deprecated ontology terms (declared as such via *owl:deprecated true*) using `-d`:  
-`python text2term -s unstruct_terms.txt -t efo.owl -d`
+`python text2term -s test/unstruct_terms.txt -t efo.owl -d`
 
 Limit search to only terms whose IRIs start with any IRI given in a list specified using `-iris`:  
-`python text2term.py -s unstruct_terms.txt -t efo.owl -iris http://www.ebi.ac.uk/efo/EFO,http://purl.obolibrary.org/obo/HP`  
+`python text2term.py -s test/unstruct_terms.txt -t efo.owl -iris http://www.ebi.ac.uk/efo/EFO,http://purl.obolibrary.org/obo/HP`  
 Here, because EFO reuses terms from other ontologies such as HP and GO, the HP terms would be included but the GO terms would be excluded.
 
 Use the cache on the command line, first by flagging it, then in the future using the acronym:
-`python text2term -s unstruct_terms.txt -t http://www.ebi.ac.uk/efo/efo.owl -c EFO`
+`python text2term -s test/unstruct_terms.txt -t http://www.ebi.ac.uk/efo/efo.owl -c EFO`
 Then, after running this, the following command is equivalent:
-`python text2term -s unstruct_terms.txt -t EFO`
+`python text2term -s test/unstruct_terms.txt -t EFO`
 
 ## Programmatic Usage
 The tool can be executed in Python with any of the three following functions:

--- a/test/simple-test.py
+++ b/test/simple-test.py
@@ -1,0 +1,14 @@
+import text2term
+
+def main():
+	efo = "http://www.ebi.ac.uk/efo/efo.owl#"
+	pizza = "https://protege.stanford.edu/ontologies/pizza/pizza.owl"
+	ncit = "http://purl.obolibrary.org/obo/ncit/releases/2022-08-19/ncit.owl"
+	if not text2term.cache_exists("EFO"):
+		text2term.cache_ontology(efo, "EFO")
+	df = text2term.map_terms(["asthma", "disease location", "obsolete food allergy"], "EFO", excl_deprecated=True, use_cache=True, term_type="classes")
+	# df = text2term.map_terms(["contains", "asthma"], efo, term_type="classes")
+	print(df.to_string())
+
+if __name__ == '__main__':
+	main()

--- a/test/test-pypi.py
+++ b/test/test-pypi.py
@@ -1,0 +1,39 @@
+from contextlib import contextmanager
+import sys, os
+import text2term
+
+def main():
+	try:
+		with suppress_stdout():
+			# Simple set up and testing
+			text2term.map_terms(["fever", "headache"], "https://github.com/EBISPOT/efo/releases/download/current/efo.owl")
+			text2term.cache_ontology("https://github.com/EBISPOT/efo/releases/download/current/efo.owl", "EFO")
+			text2term.map_terms(["fever", "headache"], "EFO", use_cache=True)
+			text2term.map_terms(["fever", "headache"], "EFO", base_iris=("www."), mapper=text2term.mapper.Mapper.levenshtein, max_mappings=4, use_cache=True)
+			
+			# Properties and classes tests
+			text2term.map_terms(["fever", "headache"], "EFO", term_type="classes", use_cache=True)
+			text2term.map_terms(["contains", "location"], "EFO", term_type="properties", use_cache=True)
+			text2term.map_terms(["fever", "contains"], "EFO", term_type="both", use_cache=True)
+
+			# Clear cache and set down
+			text2term.clear_cache("EFO")
+	except:
+		print("ERROR")
+
+# From https://stackoverflow.com/questions/2125702/how-to-suppress-console-output-in-python
+@contextmanager
+def suppress_stdout():
+    with open(os.devnull, "w") as devnull:
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        sys.stdout = devnull
+        sys.stderr = devnull
+        try:  
+            yield
+        finally:
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+
+if __name__ == '__main__':
+	main()

--- a/test/unstruct_terms.txt
+++ b/test/unstruct_terms.txt
@@ -1,0 +1,2 @@
+asthma
+acute bronchitis

--- a/text2term/__main__.py
+++ b/text2term/__main__.py
@@ -37,6 +37,8 @@ if __name__ == "__main__":
                         help="Save vis.js graphs representing the neighborhood of each ontology term (default=False)")
     parser.add_argument("-c", "--store_in_cache", required=False, type=str, default="",
                         help="Store the target ontology into local cache under acronym")
+    parser.add_argument("-type", "--term_type", required=False, type=str, default="classes",
+                        help="Define whether to return ontology classes, properties, or both")
 
     arguments = parser.parse_args()
     if not os.path.exists(arguments.source):
@@ -57,4 +59,4 @@ if __name__ == "__main__":
     map_file(arguments.source, target, output_file=arguments.output, csv_columns=csv_columns,
                          excl_deprecated=arguments.excl_deprecated, mapper=mapper, max_mappings=arguments.top_mappings,
                          min_score=arguments.min_score, base_iris=iris, save_graphs=arguments.save_term_graphs,
-                         save_mappings=True, separator=arguments.separator, use_cache=cache_exists(target))
+                         save_mappings=True, separator=arguments.separator, use_cache=cache_exists(target), term_types=arguments.term_type)

--- a/text2term/__main__.py
+++ b/text2term/__main__.py
@@ -59,4 +59,4 @@ if __name__ == "__main__":
     map_file(arguments.source, target, output_file=arguments.output, csv_columns=csv_columns,
                          excl_deprecated=arguments.excl_deprecated, mapper=mapper, max_mappings=arguments.top_mappings,
                          min_score=arguments.min_score, base_iris=iris, save_graphs=arguments.save_term_graphs,
-                         save_mappings=True, separator=arguments.separator, use_cache=cache_exists(target), term_types=arguments.term_type)
+                         save_mappings=True, separator=arguments.separator, use_cache=cache_exists(target), term_type=arguments.term_type)

--- a/text2term/config.py
+++ b/text2term/config.py
@@ -1,1 +1,1 @@
-VERSION = "2.1.0"
+VERSION = "2.2.0"

--- a/text2term/t2t.py
+++ b/text2term/t2t.py
@@ -238,6 +238,7 @@ def _load_ontology(ontology, iris, exclude_deprecated, use_cache=False, term_typ
         onto_terms_unfiltered = pickle.load(open(pickle_file, "rb"))
         onto_terms = term_collector.filter_terms(onto_terms_unfiltered, iris, exclude_deprecated, term_type)
     else:
+
         onto_terms = term_collector.get_ontology_terms(ontology, base_iris=iris, exclude_deprecated=exclude_deprecated, term_type=term_type)
     if len(onto_terms) == 0:
         raise RuntimeError("Could not find any terms in the given ontology.")

--- a/text2term/t2t.py
+++ b/text2term/t2t.py
@@ -59,11 +59,12 @@ df
 """
 def map_file(input_file, target_ontology, base_iris=(), csv_columns=(), excl_deprecated=False, max_mappings=3,
              mapper=Mapper.TFIDF, min_score=0.3, output_file='', save_graphs=False, save_mappings=False,
-             separator=',', use_cache=False):
+             separator=',', use_cache=False, term_type='classes'):
     source_terms, source_terms_ids = _load_data(input_file, csv_columns, separator)
     return map_terms(source_terms, target_ontology, source_terms_ids=source_terms_ids, base_iris=base_iris,
                     excl_deprecated=excl_deprecated, max_mappings=max_mappings, mapper=mapper, min_score=min_score,
-                    output_file=output_file, save_graphs=save_graphs, save_mappings=save_mappings, use_cache=use_cache)
+                    output_file=output_file, save_graphs=save_graphs, save_mappings=save_mappings, 
+                    use_cache=use_cache, term_type=term_type)
 
 """
 All parameters are the same as below, but tagged_terms_dict is a dictionary where the 
@@ -72,7 +73,8 @@ All parameters are the same as below, but tagged_terms_dict is a dictionary wher
     The dataframe returned is the same but contains a tags column
 """
 def map_tagged_terms(tagged_terms_dict, target_ontology, base_iris=(), excl_deprecated=False, max_mappings=3, min_score=0.3,
-        mapper=Mapper.TFIDF, output_file='', save_graphs=False, save_mappings=False, source_terms_ids=(), use_cache=False):
+        mapper=Mapper.TFIDF, output_file='', save_graphs=False, save_mappings=False, source_terms_ids=(), use_cache=False,
+        term_type='classes'):
     # If the input is a dict, use keys. If it is a list, it is a list of TaggedTerms
     if isinstance(tagged_terms_dict, dict):
         terms = list(tagged_terms_dict.keys())
@@ -89,7 +91,8 @@ def map_tagged_terms(tagged_terms_dict, target_ontology, base_iris=(), excl_depr
     # Run the mapper
     df = map_terms(terms, target_ontology, base_iris=base_iris, excl_deprecated=excl_deprecated, \
                     max_mappings=max_mappings, min_score=min_score, mapper=mapper, output_file=output_file, \
-                    save_graphs=save_graphs, source_terms_ids=source_terms_ids, use_cache=use_cache)
+                    save_graphs=save_graphs, source_terms_ids=source_terms_ids, use_cache=use_cache, \
+                    term_type=term_type)
 
     # For each term in dict, add tags to corresponding mappings row in "Tags" Column
     if isinstance(tagged_terms_dict, dict):
@@ -145,7 +148,8 @@ df
     Data frame containing the generated ontology mappings
 """
 def map_terms(source_terms, target_ontology, base_iris=(), excl_deprecated=False, max_mappings=3, min_score=0.3,
-        mapper=Mapper.TFIDF, output_file='', save_graphs=False, save_mappings=False, source_terms_ids=(), use_cache=False):
+        mapper=Mapper.TFIDF, output_file='', save_graphs=False, save_mappings=False, source_terms_ids=(), 
+        use_cache=False, term_type='classes'):
     if len(source_terms_ids) != len(source_terms):
         if len(source_terms_ids) > 0:
             sys.stderr.write("Warning: Source Term Ids are non-zero, but will not be used.")
@@ -156,7 +160,7 @@ def map_terms(source_terms, target_ontology, base_iris=(), excl_deprecated=False
     if mapper in {Mapper.ZOOMA, Mapper.BIOPORTAL}:
         target_terms = '' if target_ontology.lower() == 'all' else target_ontology
     else:
-        target_terms = _load_ontology(target_ontology, base_iris, excl_deprecated, use_cache)
+        target_terms = _load_ontology(target_ontology, base_iris, excl_deprecated, use_cache, term_type)
     mappings_df = _do_mapping(source_terms, source_terms_ids, target_terms, mapper, max_mappings, min_score)
     if save_mappings:
         _save_mappings(mappings_df, output_file, min_score, mapper, target_ontology, base_iris, excl_deprecated, max_mappings)
@@ -179,7 +183,7 @@ def cache_ontology_set(ontology_registry_path):
 
 # Caches a single ontology
 def cache_ontology(ontology_url, ontology_acronym, base_iris=()):
-    ontology_terms = _load_ontology(ontology_url, base_iris, exclude_deprecated=False)
+    ontology_terms = _load_ontology(ontology_url, base_iris, exclude_deprecated=False, term_type='both')
     cache_dir = "cache/" + ontology_acronym + "/"
     if not os.path.exists(cache_dir):
         os.makedirs(cache_dir)
@@ -189,7 +193,7 @@ def cache_ontology(ontology_url, ontology_acronym, base_iris=()):
     ontology_terms.clear()
 
 # Will check if an acronym exists in the cache
-def cache_exists(ontology_acronym):
+def cache_exists(ontology_acronym=''):
     return os.path.exists("cache/" + ontology_acronym)
 
 # Clears the cache
@@ -227,14 +231,14 @@ def _load_data(input_file_path, csv_column_names, separator):
         term_ids = onto_utils.generate_iris(len(terms))
     return terms, term_ids
 
-def _load_ontology(ontology, iris, exclude_deprecated, use_cache=False):
+def _load_ontology(ontology, iris, exclude_deprecated, use_cache=False, term_type='classes'):
     term_collector = OntologyTermCollector()
     if use_cache:
         pickle_file = "cache/" + ontology + "/" + ontology + "-term-details.pickle"
         onto_terms_unfiltered = pickle.load(open(pickle_file, "rb"))
-        onto_terms = term_collector.filter_terms(onto_terms_unfiltered, iris, exclude_deprecated)
+        onto_terms = term_collector.filter_terms(onto_terms_unfiltered, iris, exclude_deprecated, term_type)
     else:
-        onto_terms = term_collector.get_ontology_terms(ontology, base_iris=iris, exclude_deprecated=exclude_deprecated)
+        onto_terms = term_collector.get_ontology_terms(ontology, base_iris=iris, exclude_deprecated=exclude_deprecated, term_type=term_type)
     if len(onto_terms) == 0:
         raise RuntimeError("Could not find any terms in the given ontology.")
     return onto_terms

--- a/text2term/term.py
+++ b/text2term/term.py
@@ -3,7 +3,7 @@
 
 class OntologyTerm:
 
-    def __init__(self, iri, labels, definitions=(), synonyms=(), parents=(), children=(), instances=(), deprecated=False):
+    def __init__(self, iri, labels, definitions=(), synonyms=(), parents=(), children=(), instances=(), deprecated=False, termtype='class'):
         """
         Constructor for a succinct representation of an ontology term
         :param iri: IRI of the ontology term
@@ -22,6 +22,7 @@ class OntologyTerm:
         self._children = children
         self._instances = instances
         self._deprecated = deprecated
+        self._termtype = termtype
 
     @property
     def iri(self):
@@ -59,6 +60,10 @@ class OntologyTerm:
     @property
     def deprecated(self):
         return self._deprecated
+
+    @property
+    def termtype(self):
+        return self._termtype
 
     def __eq__(self, other):
         if isinstance(other, OntologyTerm):

--- a/text2term/term_mapping.py
+++ b/text2term/term_mapping.py
@@ -36,6 +36,10 @@ class TermMapping:
         return self._mapped_term_iri
 
     @property
+    def mapped_term_curie(self):
+        return onto_utils.curie_from_iri(self.mapped_term_iri)
+
+    @property
     def mapping_score(self):
         return self._mapping_score
 
@@ -44,7 +48,7 @@ class TermMapping:
             self.SRC_TERM_ID: self.source_term_id,
             self.SRC_TERM: self.source_term,
             self.TGT_TERM_LBL: self.mapped_term_label,
-            self.TGT_TERM_CURIE: onto_utils.curie_from_iri(self.mapped_term_iri),
+            self.TGT_TERM_CURIE: self.mapped_term_curie,
             self.TGT_TERM_IRI: self.mapped_term_iri,
             self.MAPPING_SCORE: self.mapping_score
         }


### PR DESCRIPTION
This update allows users to specify if they want to match over ontology classes (as is now), properties, or both. Also adds an unstruct_terms.txt example as mentioned in the README.